### PR TITLE
Update ggshield and add update-script

### DIFF
--- a/Formula/ggshield.rb
+++ b/Formula/ggshield.rb
@@ -3,8 +3,8 @@ class Ggshield < Formula
 
   desc "Detect secrets in source code, scan your repos and docker images for leaks"
   homepage "https://github.com/GitGuardian/ggshield"
-  url "https://files.pythonhosted.org/packages/e9/62/44536c9801464793b93b56b0d8b4a9b61b82846149a5319dc25ddfb1a716/ggshield-1.13.4.tar.gz"
-  sha256 "8429c4416c3968ece523c688f84edbdb483061cfba6bacf67f7b85fd0c4ccc14"
+  url "https://files.pythonhosted.org/packages/ce/a9/e0eb8b88388330390be37bb7692d7db9c8e11cdfca0c82bc4683bc73ce05/ggshield-1.13.5.tar.gz"
+  sha256 "5451d7d57a42f3043a8b550f2ef4f7d465e2696bae228c80220a88b5d8ae8676"
   license "MIT"
 
   depends_on "python3"

--- a/scripts/update-ggshield
+++ b/scripts/update-ggshield
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+"""
+Update ggshield Homebrew formula
+"""
+import argparse
+import json
+import logging
+import sys
+import time
+
+from pathlib import Path
+from subprocess import run
+from urllib import request
+
+MAX_RETRIES = 5
+RETRY_INITIAL_INTERVAL = 10
+PYPI_URL = "https://pypi.org/pypi/ggshield/json"
+
+FORMULA_PATH = Path(__file__).parent / ".." / "Formula" / "ggshield.rb"
+DESCRIPTION = (
+    "Detect secrets in source code, scan your repos and docker images for leaks"
+)
+LICENSE = "MIT"
+
+
+def install_dependencies(version: str):
+    logging.info("Installing dependencies")
+    run(["pip", "install", "homebrew-pypi-poet", f"ggshield=={version}"], check=True)
+
+
+def check_availability(version: str):
+    """Wait until pypi officially knows about the new version, otherwise poet
+    prints a warning and falls back on the previous version"""
+    retry = 1
+    interval = RETRY_INITIAL_INTERVAL
+    while True:
+        logging.info(
+            "Checking if ggshield %s is available on pypi (%d/%d)",
+            version,
+            retry,
+            MAX_RETRIES,
+        )
+        response = request.urlopen(PYPI_URL)
+        dct = json.load(response)
+        releases = dct["releases"]
+        if version in releases:
+            logging.info("ggshield %s is available", version)
+            return
+
+        if retry < MAX_RETRIES:
+            logging.warning("Not available yet, waiting %d seconds", interval)
+            time.sleep(interval)
+            retry += 1
+            interval *= 2
+        else:
+            logging.error("ggshield %s is not available on pypi", version)
+            sys.exit(2)
+
+
+def update_formula():
+    logging.info("Updating %s", FORMULA_PATH)
+
+    # Generate the new formula
+    proc = run(["poet", "--formula", "ggshield"], check=True, capture_output=True)
+    content = proc.stdout.decode("utf-8")
+
+    # Replace description
+    content = content.replace("Shiny new formula", DESCRIPTION)
+    lines = content.split("\n")
+
+    # Insert license line at the end of the first group. The group should end
+    # with a "sha256" entry
+    assert "sha256" in lines[6]
+    lines.insert(7, f'  license "{LICENSE}"')
+    content = "\n".join(lines)
+
+    # Write the result
+    FORMULA_PATH.write_text(content)
+
+
+def commit_changes(version: str):
+    logging.info("Committing changes")
+    run(["git", "add", FORMULA_PATH], check=True)
+    run(["git", "commit", "-m", f"chore: update ggshield to {version}"], check=True)
+
+
+def main():
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt='%H:%M:%S')
+
+    parser = argparse.ArgumentParser(
+        formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__
+    )
+    parser.add_argument("-c", "--commit", action="store_true", help="Commit changes")
+    parser.add_argument("version", help="ggshield version")
+    args = parser.parse_args()
+
+    if not FORMULA_PATH.exists():
+        logging.error("%s does not exist", FORMULA_PATH)
+        sys.exit(1)
+
+    check_availability(args.version)
+    install_dependencies(args.version)
+    update_formula()
+    if args.commit:
+        commit_changes(args.version)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())
+# vi: ts=4 sw=4 et


### PR DESCRIPTION
## Description

This PR does two things:

1. Update ggshield to 1.13.5, for real this time.
2. Add a script to do the update. The script does what ggshield CI do, but it also waits until pypi.org is aware of the new version before running poet. This should avoid our previous issues.

Having a script makes it easier to debug the update or to rerun the process manually.

The script does not create a tag: it is not necessary (src-fingerprint updates do not generate tags either) and not having a tag makes it less awkward to fix updates manually in case the automated update goes wrong.

The script can automate the commit but does not push, giving you a chance to review the changes before they go in.

## ggshield CI

Assuming this gets in, I will then update ggshield CI to run this script instead of using its own commands.
