### PR TITLE
Make ggshield formula support Rust-based dependencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,6 @@ build-iPhoneSimulator/
 
 # Used by RuboCop. Remote config files pulled in from inherit_from directive.
 # .rubocop-https?--*
+
+# Where scripts/update-ggshield checkouts ggshield repo
+/work/

--- a/Formula/ggshield.rb
+++ b/Formula/ggshield.rb
@@ -9,6 +9,10 @@ class Ggshield < Formula
 
   depends_on "python3"
 
+  # The `cryptography` package needs these
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+
   resource "appdirs" do
     url "https://files.pythonhosted.org/packages/d7/d8/05696357e0311f5b5c316d7b95f46c669dd9c15aaeecbb48c7d0aeb88c40/appdirs-1.4.4.tar.gz"
     sha256 "7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41"
@@ -70,8 +74,8 @@ class Ggshield < Formula
   end
 
   resource "Pygments" do
-    url "https://files.pythonhosted.org/packages/89/6b/2114e54b290824197006e41be3f9bbe1a26e9c39d1f5fa20a6d62945a0b3/Pygments-2.15.1.tar.gz"
-    sha256 "8ace4d3c1dd481894b2005f560ead0f9f19ee64fe983366be1a21e171d12775c"
+    url "https://files.pythonhosted.org/packages/d6/f7/4d461ddf9c2bcd6a4d7b2b139267ca32a69439387cc1f02a924ff8883825/Pygments-2.16.1.tar.gz"
+    sha256 "1daff0494820c69bc8941e407aa20f577374ee88364ee10a98fdbe0aece96e29"
   end
 
   resource "PyJWT" do
@@ -120,6 +124,8 @@ class Ggshield < Formula
   end
 
   test do
-    false
+    # In an environment with no API key, `ggshield api-status` exits with
+    # status code 3 and tells the user to login
+    assert_match "ggshield auth login", shell_output("#{bin}/ggshield api-status 2>&1", 3)
   end
 end

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -1,0 +1,28 @@
+# About this directory
+
+This directory contains tools to help managing this repository.
+
+## update-ggshield
+
+This script can be used to update ggshield Homebrew formula. It is a wrapper around [poet](https://github.com/tdsmith/homebrew-pypi-poet).
+
+To run it for a released version of ggshield, use `./update-ggshield <version>`.
+
+To run it for a git branch or a commit, use `./update-ggshield --from-git <branch-or-commit>`.
+
+Note: due to a limitation in poet, the script does not correctly handle unreleased dependencies: if ggshield currently depends on a commit of py-gitguardian, whose latest released version is 1.8.0, then the generated Homebrew formula is going to include py-gitguardian 1.8.0.
+
+## docker/Dockerfile
+
+The Dockerfile can be used to setup a clean system with the Linux version of Homebrew installed.
+
+Usage:
+
+- Build the image: `docker build -t homebrew docker`
+- Start a container using the image: `docker run -it --rm -v $PWD/..:/home/linuxbrew/src homebrew`
+- Inside the container:
+    - `cd src/Formula`
+    - build the package: `brew install --verbose ggshield.rb`
+    - run tests: `brew test ggshield.rb`
+
+Note: when testing with a git branch, you will have to either alter the `url` field of `Formula/ggshield.rb` so that brew finds it inside the Docker container, or add an additional `-v` option to the `docker run` call to map the path to the archive inside the container.

--- a/scripts/docker/Dockerfile
+++ b/scripts/docker/Dockerfile
@@ -1,0 +1,26 @@
+from ubuntu:22.04
+
+RUN apt-get update -y \
+    && apt-get install -y --no-install-recommends \
+        ca-certificates \
+        curl \
+        g++ \
+        git \
+        libstdc++-11-dev \
+        make \
+        sudo \
+        zlib1g-dev
+
+RUN useradd --create-home linuxbrew \
+    && usermod -a -G sudo linuxbrew \
+    && echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
+
+USER linuxbrew
+WORKDIR /home/linuxbrew
+
+RUN NONINTERACTIVE=1 \
+    bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
+
+RUN echo "export PATH=$HOME/.linuxbrew/bin:$PATH" >> .bashrc
+
+CMD bash

--- a/scripts/update-ggshield
+++ b/scripts/update-ggshield
@@ -4,7 +4,10 @@ Update ggshield Homebrew formula
 """
 import argparse
 import json
+import hashlib
 import logging
+import re
+import shutil
 import sys
 import time
 
@@ -16,21 +19,59 @@ MAX_RETRIES = 5
 RETRY_INITIAL_INTERVAL = 10
 PYPI_URL = "https://pypi.org/pypi/ggshield/json"
 
-FORMULA_PATH = Path(__file__).parent / ".." / "Formula" / "ggshield.rb"
-DESCRIPTION = (
-    "Detect secrets in source code, scan your repos and docker images for leaks"
-)
-LICENSE = "MIT"
+REPO_DIR = Path(__file__).parent.parent
+FORMULA_PATH = REPO_DIR / "Formula" / "ggshield.rb"
+WORK_DIR = REPO_DIR / "work"
+
+GGSHIELD_REPO_URL = "https://github.com/GitGuardian/ggshield"
+
+FORMULA_TEMPLATE = """class Ggshield < Formula
+  include Language::Python::Virtualenv
+
+  desc "Detect secrets in source code, scan your repos and docker images for leaks"
+  homepage "https://github.com/GitGuardian/ggshield"
+  url "{url}"
+  sha256 "{sha256}"
+  license "MIT"
+
+  depends_on "python3"
+
+  {resources}
+
+  def install
+    virtualenv_create(libexec, "python3")
+    virtualenv_install_with_resources
+  end
+end
+"""
 
 
-def install_dependencies(version: str):
-    logging.info("Installing dependencies")
-    run(["pip", "install", "homebrew-pypi-poet", f"ggshield=={version}"], check=True)
+def build_sdist(commit_ref: str) -> Path:
+    """Builds an sdist, returns the path to the sdist"""
+    if WORK_DIR.exists():
+        shutil.rmtree(WORK_DIR)
+    WORK_DIR.mkdir()
+    logging.info("Cloning repository at %s", commit_ref)
+    run(["git", "clone", "--depth", "1", GGSHIELD_REPO_URL, "--branch", commit_ref, WORK_DIR], check=True)
+    logging.info("Building sdist")
+    run(["python", "setup.py", "sdist"], check=True, cwd=WORK_DIR)
+    return next(WORK_DIR.glob("dist/*.tar.gz"))
 
 
-def check_availability(version: str):
-    """Wait until pypi officially knows about the new version, otherwise poet
-    prints a warning and falls back on the previous version"""
+def compute_sha256sum(path: Path) -> str:
+    logging.info("Computing sha256sum")
+    hash_ = hashlib.new("sha256")
+    hash_.update(path.read_bytes())
+    return hash_.hexdigest()
+
+
+def install_dependencies(ggshield_pip_arg: str):
+    logging.info("Installing dependencies, (%s)", ggshield_pip_arg)
+    run(["pip", "install", "homebrew-pypi-poet", ggshield_pip_arg], check=True)
+
+
+def check_availability(version: str) -> tuple[str, str]:
+    """Find the package on pypi, returns a tuple of (url, sha256)"""
     retry = 1
     interval = RETRY_INITIAL_INTERVAL
     while True:
@@ -43,9 +84,13 @@ def check_availability(version: str):
         response = request.urlopen(PYPI_URL)
         dct = json.load(response)
         releases = dct["releases"]
-        if version in releases:
+        if release := releases[version]:
             logging.info("ggshield %s is available", version)
-            return
+            for artifact in release:
+                if artifact["packagetype"] == "sdist":
+                    return (artifact["url"], artifact["digests"]["sha256"])
+            logging.error("no sdist found for version %s", version)
+            sys.exit(3)
 
         if retry < MAX_RETRIES:
             logging.warning("Not available yet, waiting %d seconds", interval)
@@ -57,24 +102,24 @@ def check_availability(version: str):
             sys.exit(2)
 
 
-def update_formula():
+def update_formula(url: str, sha256: str):
     logging.info("Updating %s", FORMULA_PATH)
 
-    # Generate the new formula
-    proc = run(["poet", "--formula", "ggshield"], check=True, capture_output=True)
-    content = proc.stdout.decode("utf-8")
+    # Get resources
+    proc = run(["poet", "--resources", "ggshield"], check=True, capture_output=True)
+    resources = proc.stdout.decode("utf-8").strip()
 
-    # Replace description
-    content = content.replace("Shiny new formula", DESCRIPTION)
-    lines = content.split("\n")
+    # poet adds ggshield itself as a resource: remove it
+    resources, count = re.subn(
+        r'  resource "ggshield" do.*?end\n\n',
+        "",
+        resources,
+        flags=re.DOTALL,
+    )
+    assert count == 1
 
-    # Insert license line at the end of the first group. The group should end
-    # with a "sha256" entry
-    assert "sha256" in lines[6]
-    lines.insert(7, f'  license "{LICENSE}"')
-    content = "\n".join(lines)
-
-    # Write the result
+    # Fill the template and write the result
+    content = FORMULA_TEMPLATE.format(url=url, sha256=sha256, resources=resources)
     FORMULA_PATH.write_text(content)
 
 
@@ -91,18 +136,38 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__
     )
     parser.add_argument("-c", "--commit", action="store_true", help="Commit changes")
-    parser.add_argument("version", help="ggshield version")
+    parser.add_argument(
+        "--from-git",
+        action="store_true",
+        help=(
+            "Instead of pulling from Pypi, checkout ggshield git repository,"
+            " build an sdist from it and use it for the package"
+        ),
+    )
+    parser.add_argument(
+        "version_or_commit_ref",
+        help="Version to package, or Git commit ref when called with --from-git",
+    )
     args = parser.parse_args()
 
     if not FORMULA_PATH.exists():
         logging.error("%s does not exist", FORMULA_PATH)
         sys.exit(1)
 
-    check_availability(args.version)
-    install_dependencies(args.version)
-    update_formula()
-    if args.commit:
-        commit_changes(args.version)
+    if args.from_git:
+        archive_path = build_sdist(args.version_or_commit_ref)
+        url = f"file://{archive_path}"
+        sha256 = compute_sha256sum(archive_path)
+        install_dependencies(str(archive_path))
+    else:
+        version = args.version_or_commit_ref
+        url, sha256 = check_availability(version)
+        install_dependencies(f"ggshield=={version}")
+
+    update_formula(url, sha256)
+
+    if not args.from_git and args.commit:
+        commit_changes(args.from_pypi)
 
     return 0
 

--- a/scripts/update-ggshield
+++ b/scripts/update-ggshield
@@ -36,6 +36,10 @@ FORMULA_TEMPLATE = """class Ggshield < Formula
 
   depends_on "python3"
 
+  # The `cryptography` package needs these
+  depends_on "pkg-config" => :build
+  depends_on "rust" => :build
+
   {resources}
 
   def install

--- a/scripts/update-ggshield
+++ b/scripts/update-ggshield
@@ -142,6 +142,8 @@ def commit_changes(version: str):
 def main():
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s", datefmt='%H:%M:%S')
 
+    # Be careful when changing the arguments here: this script is used by the
+    # tag.yml workflow of ggshield
     parser = argparse.ArgumentParser(
         formatter_class=argparse.RawDescriptionHelpFormatter, description=__doc__
     )

--- a/scripts/update-ggshield
+++ b/scripts/update-ggshield
@@ -46,6 +46,12 @@ FORMULA_TEMPLATE = """class Ggshield < Formula
     virtualenv_create(libexec, "python3")
     virtualenv_install_with_resources
   end
+
+  test do
+    # In an environment with no API key, `ggshield api-status` exits with
+    # status code 3 and tells the user to login
+    assert_match "ggshield auth login", shell_output("#{{bin}}/ggshield api-status 2>&1", 3)
+  end
 end
 """
 


### PR DESCRIPTION
## Context

ggshield 1.17.1 introduced a new group of commands: hmsl. These commands used the Python  `cryptography` package, which requires Rust to build. Unfortunately, ggshield Homebrew package did not support this, so as a quick fix we released ggshield 1.17.2 which made that dependency optional.

The goal of this PR is to make our Homebrew package able to include the Python cryptography package.

## What has been done

This PR does the following:
- Add a Docker image to make it simple to test on Linux.
- Refactor scripts/update-ggshield: until now the script used homebrew-pypi-poet to generate the whole `Formula/ggshield.rb` file and then patched the generated content using search&replace. This was brittle and painful to extend.
  Now the script has its own formula template, and only uses homebrew-pypi-poet to fill the `resources` field of the template. This makes it simpler to add new features to the formula.
  The refactor also adds support for building a formula from a git branch. This is useful for testing.
- Add to the formula the necessary commands to build the cryptography package, and a brew test.
- Document the `scripts` dir.
- And finally, update the committed ggshield formula!