### PR TITLE
Install a specific version of Python

### DIFF
--- a/.github/workflows/update-ggshield.yml
+++ b/.github/workflows/update-ggshield.yml
@@ -17,6 +17,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
+      - name: Set up Python 3.11
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.11
+
       - name: Update formula
         run: |
           args=${{ inputs.version_or_commit_ref }}


### PR DESCRIPTION
The Python version running on GitHub macOS runner is too old for scripts/update-ggshield.
