### PR TITLE
Update README to mark this repository as deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,7 @@
 # GitGuardian Homebrew Tap
 
-This repository hosts Homebrew tap for [GitGuardian](http://gitguardian.com/)'s tools.  
+![Deprecated](https://img.shields.io/badge/status-deprecated-red)
 
-## What is Homebrew ?
-Homebrew is a Package manager for macOS (or Linux), see more doc at https://brew.sh/
+This repository used to host an Homebrew tap for [GGShield](http://github.com/GitGuardian/ggshield), but it is now deprecated.
 
-## What is a tap ?
-A tap is a third-party repository providing installable packages. For more information, you can have a look at this [documentation](https://docs.brew.sh/Taps).
-
-## How to install packages from GitGuardian's tap ?  
-#### Straight to the point
-Type this one-liner to quickly install your package.  
-```sh
-brew install gitguardian/tap/PACKAGE_NAME
-```
-
-#### Add tap and download the package
-Type these commands if you plan to use GitGuardian's tap in the long run.
-```sh
-brew tap gitguardian/tap
-```
-This command adds GitGuardian's tap to your taps, and it makes GitGuardian's packages available in search results yielded by `brew search`. You can then run the following command :  
-```sh
-brew install PACKAGE_NAME
-```
-
-## How to upgrade a package from Homebrew ?
-```sh
-brew update
-brew upgrade PACKAGE_NAME
-```
+To install GGShield using Homebrew, use `brew install ggshield`.


### PR DESCRIPTION
Using this tap is no longer necessary now that GGShield is in Homebrew core.